### PR TITLE
Added Java 1.7 source compatibility

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,6 +6,11 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
 }
 
+tasks.withType(JavaCompile) {
+    sourceCompatibility = "1.7"
+    targetCompatibility = "1.7"
+}
+
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource


### PR DESCRIPTION
Added this because if the project uses Java 1.8 it's cannot build APK and show this error:

> Error:Error converting bytecode to dex:
Cause: Dex cannot parse version 52 byte code.
This is caused by library dependencies that have been compiled using Java 8 or above.
If you are using the 'java' gradle plugin in a library submodule add 
targetCompatibility = '1.7'
sourceCompatibility = '1.7'
to that submodule's build.gradle file.